### PR TITLE
Fix forced wait log and add EOS tokens in prompts

### DIFF
--- a/Simulation/prompt_builder.py
+++ b/Simulation/prompt_builder.py
@@ -59,10 +59,18 @@ class ModelConfig:
                 observation_section += f"<observation>\n{environment_static_observations}\n</observation>\n\n"
         
         if self.has_system_prompt:
-            return f"{self.system_token}\n{system_prompt}\n\n{observation_section}{self.user_token}\n{user_prompt}\n\n{self.assistant_token}\n"
+            return (
+                f"{self.system_token}\n{system_prompt}\n\n"
+                f"{observation_section}{self.user_token}\n{user_prompt}\n\n"
+                f"{self.assistant_token}\n{self.end_token}"
+            )
         else:
             # Models like Gemma treat system prompt as additional user prompt
-            return f"{self.user_token}\n{system_prompt}\n\n{observation_section}{self.user_token}\n{user_prompt}\n\n{self.assistant_token}\n"
+            return (
+                f"{self.user_token}\n{system_prompt}\n\n"
+                f"{observation_section}{self.user_token}\n{user_prompt}\n\n"
+                f"{self.assistant_token}\n{self.end_token}"
+            )
 
 
 # Default model configurations

--- a/runner/match_runner.py
+++ b/runner/match_runner.py
@@ -210,6 +210,10 @@ class MatchRunner:
                         "forced_wait": True,
                     }
                 )
+                ctx.prompt_history.append({
+                    "role": "assistant",
+                    "content": "<think>\nNo valid action produced; forcing wait.\n</think>\n<wait/>"
+                })
                 break
             if not ctx.prompt_history:
                 system_prompt = build_complete_prompt(self.game, ctx.player, "gemma")


### PR DESCRIPTION
## Summary
- append a message to `prompt_history` when the match runner forces a wait
- include the model end token at the end of prompts

## Testing
- `pytest -q` *(fails: cannot access gated HuggingFace repo, NVML library not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ffe40790c8330be8dd062481838e1